### PR TITLE
Migration Fixes

### DIFF
--- a/project/migrations/forms/0002_initial_translation_fields.py
+++ b/project/migrations/forms/0002_initial_translation_fields.py
@@ -8,6 +8,21 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
+        # Adding field 'Form.title_en'
+        db.add_column(u'forms_form', 'title_en',
+                      self.gf('django.db.models.fields.CharField')(max_length=500, null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Form.description_en'
+        db.add_column(u'forms_form', 'description_en',
+                      self.gf('django.db.models.fields.TextField')(null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Form.content_en'
+        db.add_column(u'forms_form', 'content_en',
+                      self.gf('mezzanine.core.fields.RichTextField')(null=True, blank=True),
+                      keep_default=False)
+
         # Adding field 'Form.button_text_en'
         db.add_column(u'forms_form', 'button_text_en',
                       self.gf('django.db.models.fields.CharField')(default=u'Submit', max_length=50, null=True, blank=True),
@@ -44,6 +59,15 @@ class Migration(SchemaMigration):
                       keep_default=False)
 
     def backwards(self, orm):
+        # Deleting field 'Form.title_en'
+        db.delete_column(u'forms_form', 'title_en')
+
+        # Deleting field 'Form.description_en'
+        db.delete_column(u'forms_form', 'description_en')
+
+        # Deleting field 'Form.content_en'
+        db.delete_column(u'forms_form', 'content_en')
+        
         # Deleting field 'Form.button_text_en'
         db.delete_column(u'forms_form', 'button_text_en')
 

--- a/project/migrations/pages/0002_initial_translation_fields.py
+++ b/project/migrations/pages/0002_initial_translation_fields.py
@@ -13,8 +13,23 @@ class Migration(SchemaMigration):
                       self.gf('django.db.models.fields.CharField')(max_length=500, null=True, blank=True),
                       keep_default=False)
 
+        # Adding field 'Link.title_en'
+        db.add_column(u'pages_link', 'title_en',
+                      self.gf('django.db.models.fields.CharField')(max_length=500, null=True, blank=True),
+                      keep_default=False)
+
         # Adding field 'Page.description_en'
         db.add_column(u'pages_page', 'description_en',
+                      self.gf('django.db.models.fields.TextField')(null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'RichTextPage.title_en'
+        db.add_column(u'pages_richtextpage', 'title_en',
+                      self.gf('django.db.models.fields.CharField')(max_length=500, null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'RichTextPage.description_en'
+        db.add_column(u'pages_richtextpage', 'description_en',
                       self.gf('django.db.models.fields.TextField')(null=True, blank=True),
                       keep_default=False)
 
@@ -27,12 +42,20 @@ class Migration(SchemaMigration):
         # Deleting field 'Page.title_en'
         db.delete_column(u'pages_page', 'title_en')
 
+        # Deleting field 'Link.title_en'
+        db.delete_column(u'pages_link', 'title_en')
+
         # Deleting field 'Page.description_en'
         db.delete_column(u'pages_page', 'description_en')
 
+        # Deleting field 'RichTextPage.title_en'
+        db.delete_column(u'pages_richtextpage', 'title_en')
+
+        # Deleting field 'RichTextPage.description_en'
+        db.delete_column(u'pages_richtextpage', 'description_en')
+
         # Deleting field 'RichTextPage.content_en'
         db.delete_column(u'pages_richtextpage', 'content_en')
-
 
     models = {
         u'pages.link': {


### PR DESCRIPTION
It looks like my changes in #9 were too aggressive in removing columns to be added. django-modeltranslation wants the columns to exist in both the `Page` and subclassed tables `Link`, `Form`, `RichTextPage`. The frozen ORM can't include them in both models because it will clash with the base model.

Tested with a fresh DB.
