### PR TITLE
[46] Adjust Custom Fields

### DIFF
--- a/project/settings/base.py
+++ b/project/settings/base.py
@@ -53,21 +53,28 @@ from __future__ import absolute_import, unicode_literals
 #
 EXTRA_MODEL_FIELDS = (
     (
-        "mezzanine.pages.models.Page.subtitle",
-        "CharField",  # 'django.db.models.' is implied if path is omitted.
-        ("Subtitle",),
-        {"max_length": 128, "default": '', "blank": True},
-    ),
-    (
         "mezzanine.pages.models.Page.intro",
         "TextField",  # 'django.db.models.' is implied if path is omitted.
         ("Intro Paragraph",),
         {"default": '', "blank": True},
     ),
     (
-        "mezzanine.pages.models.Page.closing",
-        "TextField",  # 'django.db.models.' is implied if path is omitted.
-        ("Closing Paragraph",),
+        "mezzanine.pages.models.Page.inherit",
+        "BooleanField",
+        ("Display Root Parent Title and Intro",),
+        {"default": '', "blank": True,
+         "help_text": "If selected, the page will render using the root parent's Title and Intro in the masthead."},
+    ),
+    (
+        "mezzanine.pages.models.Page.cta_title",
+        "CharField",  # 'django.db.models.' is implied if path is omitted.
+        ("Call to Action Title",),
+        {"max_length": 128, "default": '', "blank": True},
+    ),
+    (
+        "mezzanine.pages.models.Page.cta_body",
+        "mezzanine.core.fields.RichTextField",
+        ("Call to Action Body",),
         {"default": '', "blank": True},
     ),
 )

--- a/sandstone/admin.py
+++ b/sandstone/admin.py
@@ -7,10 +7,11 @@ from mezzanine.pages.models import RichTextPage
 
 
 rt_page_fieldsets = deepcopy(PageAdmin.fieldsets)
-rt_page_fieldsets[0][1]["fields"].insert(3, "subtitle")
-rt_page_fieldsets[0][1]["fields"].insert(4, "intro")
-rt_page_fieldsets[0][1]["fields"].insert(5, "content")
-rt_page_fieldsets[0][1]["fields"].insert(6, "closing")
+rt_page_fieldsets[0][1]["fields"].insert(3, "intro")
+rt_page_fieldsets[0][1]["fields"].insert(4, "inherit")
+rt_page_fieldsets[0][1]["fields"].insert(5, "cta_title")
+rt_page_fieldsets[0][1]["fields"].insert(6, "cta_body")
+rt_page_fieldsets[0][1]["fields"].insert(7, "content")
 
 
 class SandstoneRichTextPageAdmin(PageAdmin):

--- a/sandstone/migrations/0002_page_add_cta_fields.py
+++ b/sandstone/migrations/0002_page_add_cta_fields.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Page.cta_title'
+        db.add_column(u'pages_page', u'cta_title',
+                      self.gf('django.db.models.fields.CharField')(default=u'', max_length=128, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Page.cta_body'
+        db.add_column(u'pages_page', u'cta_body',
+                      self.gf('mezzanine.core.fields.RichTextField')(default=u'', blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Page.cta_title'
+        db.delete_column(u'pages_page', u'cta_title')
+
+        # Deleting field 'Page.cta_body'
+        db.delete_column(u'pages_page', u'cta_body')
+
+
+    models = {
+        u'pages.link': {
+            'Meta': {'ordering': "(u'_order',)", 'object_name': 'Link', '_ormbases': [u'pages.Page']},
+            u'page_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['pages.Page']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'pages.page': {
+            'Meta': {'ordering': "(u'titles',)", 'object_name': 'Page'},
+            '_meta_title': ('django.db.models.fields.CharField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'}),
+            '_order': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            u'closing': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            'content_model': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            u'cta_body': ('mezzanine.core.fields.RichTextField', [], {'default': "u''", 'blank': 'True'}),
+            u'cta_title': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '128', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'expiry_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'gen_description': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'in_menus': ('mezzanine.pages.fields.MenusField', [], {'default': '(1, 2, 3)', 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'in_sitemap': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'intro': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            u'keywords_string': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'login_required': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'children'", 'null': 'True', 'to': u"orm['pages.Page']"}),
+            'publish_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'short_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['sites.Site']"}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            u'subtitle': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '128', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'titles': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'null': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'null': 'True'})
+        },
+        u'pages.richtextpage': {
+            'Meta': {'ordering': "(u'_order',)", 'object_name': 'RichTextPage', '_ormbases': [u'pages.Page']},
+            'content': ('mezzanine.core.fields.RichTextField', [], {}),
+            u'page_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['pages.Page']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'sites.site': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'Site', 'db_table': "u'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['pages']

--- a/sandstone/migrations/0003_populate_cta_fields.py
+++ b/sandstone/migrations/0003_populate_cta_fields.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        # Note: Don't use "from appname.models import ModelName".
+        # Use orm.ModelName to refer to models in this application,
+        # and orm['appname.ModelName'] for models in other applications.
+        # Page model not accessible via the suggested orm method
+        from mezzanine.pages.models import Page
+        Page.objects.all().update(cta_title=models.F('subtitle'),cta_body=models.F('closing'))
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+    models = {
+
+    }
+
+    complete_apps = ['sandstone']
+    symmetrical = True

--- a/sandstone/migrations/0004_remove_subtitle_closing.py
+++ b/sandstone/migrations/0004_remove_subtitle_closing.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'Page.subtitle'
+        db.delete_column(u'pages_page', u'subtitle')
+
+        # Deleting field 'Page.closing'
+        db.delete_column(u'pages_page', u'closing')
+
+
+    def backwards(self, orm):
+        # Adding field 'Page.subtitle'
+        db.add_column(u'pages_page', u'subtitle',
+                      self.gf('django.db.models.fields.CharField')(default=u'', max_length=128, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Page.closing'
+        db.add_column(u'pages_page', u'closing',
+                      self.gf('django.db.models.fields.TextField')(default=u'', blank=True),
+                      keep_default=False)
+
+
+
+    models = {
+        u'pages.link': {
+            'Meta': {'ordering': "(u'_order',)", 'object_name': 'Link', '_ormbases': [u'pages.Page']},
+            u'page_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['pages.Page']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'pages.page': {
+            'Meta': {'ordering': "(u'titles',)", 'object_name': 'Page'},
+            '_meta_title': ('django.db.models.fields.CharField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'}),
+            '_order': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'content_model': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            u'cta_body': ('mezzanine.core.fields.RichTextField', [], {'default': "u''", 'blank': 'True'}),
+            u'cta_title': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '128', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'expiry_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'gen_description': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'in_menus': ('mezzanine.pages.fields.MenusField', [], {'default': '(1, 2, 3)', 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'in_sitemap': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'intro': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            u'keywords_string': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'login_required': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'children'", 'null': 'True', 'to': u"orm['pages.Page']"}),
+            'publish_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'short_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['sites.Site']"}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'titles': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'null': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'null': 'True'})
+        },
+        u'pages.richtextpage': {
+            'Meta': {'ordering': "(u'_order',)", 'object_name': 'RichTextPage', '_ormbases': [u'pages.Page']},
+            'content': ('mezzanine.core.fields.RichTextField', [], {}),
+            u'page_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['pages.Page']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'sites.site': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'Site', 'db_table': "u'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['pages']

--- a/sandstone/migrations/0005_add_inherit.py
+++ b/sandstone/migrations/0005_add_inherit.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Page.inherit'
+        db.add_column(u'pages_page', u'inherit',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Page.inherit'
+        db.delete_column(u'pages_page', u'inherit')
+
+
+    models = {
+        u'pages.link': {
+            'Meta': {'ordering': "(u'_order',)", 'object_name': 'Link', '_ormbases': [u'pages.Page']},
+            u'page_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['pages.Page']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'pages.page': {
+            'Meta': {'ordering': "(u'titles',)", 'object_name': 'Page'},
+            '_meta_title': ('django.db.models.fields.CharField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'}),
+            '_order': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'content_model': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            u'cta_body': ('mezzanine.core.fields.RichTextField', [], {'default': "u''", 'blank': 'True'}),
+            u'cta_title': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '128', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'expiry_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'gen_description': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'in_menus': ('mezzanine.pages.fields.MenusField', [], {'default': '(1, 2, 3)', 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'in_sitemap': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'inherit': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'intro': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            u'keywords_string': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'login_required': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'children'", 'null': 'True', 'to': u"orm['pages.Page']"}),
+            'publish_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'short_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['sites.Site']"}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'titles': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'null': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'null': 'True'})
+        },
+        u'pages.richtextpage': {
+            'Meta': {'ordering': "(u'_order',)", 'object_name': 'RichTextPage', '_ormbases': [u'pages.Page']},
+            'content': ('mezzanine.core.fields.RichTextField', [], {}),
+            u'page_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['pages.Page']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'sites.site': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'Site', 'db_table': "u'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['pages']


### PR DESCRIPTION
Fixes #46 

Due to the way Mezzanine incorporates custom fields via the settings file, the migration for this PR requires special attention:

To run the migrations, in `project.settings.base.EXTRA_MODEL_FIELDS`, you'll need to temporarily include the removed fields:

```
    (
        "mezzanine.pages.models.Page.closing",
        "TextField",  # 'django.db.models.' is implied if path is omitted.
        ("Closing Paragraph",),
        {"default": '', "blank": True},
    ),
     (
        "mezzanine.pages.models.Page.subtitle",
        "CharField",  # 'django.db.models.' is implied if path is omitted.
        ("Subtitle",),
        {"max_length": 128, "default": '', "blank": True},
    )
```

Then execute:

`python manage.py migrate sandstone`

Once that is complete, remove the temp fields from `project.settings.base.EXTRA_MODEL_FIELDS`.

We likely should collapse the migrations at some point after these are run for fxoss, as the migration instructions for a new site or not straightforward either.
