### PR TITLE
enable reg now that BasicAuth is back in place

### DIFF
--- a/project/settings/base.py
+++ b/project/settings/base.py
@@ -265,7 +265,7 @@ INSTALLED_APPS = [
     "mezzanine.generic",
     "mezzanine.forms",
     "mezzanine.pages",
-    #"mezzanine.accounts",
+    "mezzanine.accounts",
     #"mezzanine.mobile",
     "registration_salesforce",
     'protected_assets',


### PR DESCRIPTION
Activate `mezzanine.accounts` in base settings.

Prior to BasicAuth being enabled, I have enabled the app via local.py. Now that BasicAuth is back in the mix, we should be safe to enable this app by default.

If you have added `INSTALLED_APPS = base.INSTALLED_APPS + ['mezzanine.accounts']` to local.py, remove it once this is merged in.
