### PR TITLE
Add editable profile fields to fix bug 1012905

### DIFF
--- a/project/settings/base.py
+++ b/project/settings/base.py
@@ -352,10 +352,12 @@ USE_X_FORWARDED_HOST = True
 ACCOUNTS_VERIFICATION_REQUIRED = True
 # Email as username
 ACCOUNTS_NO_USERNAME = True
-# set to True to include additional form fields for debugging Salesforce
-# Integration
-DEBUG_SALESFORCE = False
 
+ACCOUNTS_PROFILE_FORM_CLASS = (
+    'registration_salesforce.forms.UserRegistrationLeadForm')
+ACCOUNTS_PROFILE_FORM_EXCLUDE_FIELDS = (
+    'salesforce_id', 'salesforce_sync', 'last_salesforce_sync')
+AUTH_PROFILE_MODULE = 'registration_salesforce.Profile'
 ###############################
 # django-concurrency settings #
 ###############################
@@ -414,6 +416,7 @@ NOSE_ARGS = ['--logging-filter=-concurrency,-south']
 
 LOGGING = {
     'version': 1,
+    'disable_existing_loggers': False,
     'filters': {
         'require_debug_false': {
             '()': 'django.utils.log.RequireDebugFalse'

--- a/registration_salesforce/forms.py
+++ b/registration_salesforce/forms.py
@@ -3,17 +3,11 @@ from random import randrange
 
 from django import forms
 from django.forms import widgets
-from django.contrib.auth import authenticate
-from django.contrib.auth.tokens import default_token_generator
-from django.utils import timezone
-from django.utils.http import int_to_base36
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
-from mezzanine.conf import settings
-from mezzanine.core.forms import Html5Mixin
+from mezzanine.accounts.forms import ProfileForm
 from mezzanine.utils.models import get_user_model
-from mezzanine.utils.urls import slugify, unique_slug
 
 from .models import Profile
 
@@ -21,24 +15,18 @@ from .models import Profile
 User = get_user_model()
 
 
-def create_or_update_profile(user, data):
-    data['modified'] = timezone.now()
-    profile_kwargs = {field.name: data[field.name]
-                      for field in Profile._meta.fields
-                      if data.get(field.name)}
-
-    if not Profile.objects.filter(user=user).update(**profile_kwargs):
-        Profile.objects.create(user=user, **profile_kwargs)
-
-
 class HoneyPotWidget(widgets.CheckboxInput):
-    """Render a checkbox to (hopefully) trick bots. Will be used on many pages."""
+    """
+    Render a checkbox to (hopefully) trick bots. Will be used on many pages.
+    """
 
     def render(self, name, value, attrs=None):
         honeypot_txt = _(u'Check this box if you are not human.')
         # semi-randomized in case we have more than one per page.
         # this is maybe/probably overthought
-        honeypot_id = 'super-priority-%s-%s' % (str(randrange(1001)), str(datetime.now().strftime("%Y%m%d%H%M%S%f")))
+        honeypot_id = 'super-priority-{}-{}'.format(
+            str(randrange(1001)),
+            str(datetime.now().strftime("%Y%m%d%H%M%S%f")))
         return mark_safe(
             '<div class="super-priority-field">'
             '<label for="%s" class="super-priority-check-label">%s</label>'
@@ -46,278 +34,26 @@ class HoneyPotWidget(widgets.CheckboxInput):
             '</div>' % (honeypot_id, honeypot_txt, honeypot_id))
 
 
-class UserRegistrationLeadForm(Html5Mixin, forms.ModelForm):
+class UserRegistrationLeadForm(ProfileForm):
     """
     ModelForm for auth.User - used for signup and profile update.
-
-    NOTE: Profile Model field injection as defined by ``AUTH_PROFILE_MODULE``
-    is disabled in this implementation!
     """
-
-    password1 = forms.CharField(label=_("Password"),
-                                widget=forms.PasswordInput(render_value=False))
-    password2 = forms.CharField(label=_("Password (again)"),
-                                widget=forms.PasswordInput(render_value=False))
-    first_name = forms.CharField(
-        max_length=40,
-        required=True,
-        error_messages={
-            'required': _('Please enter your first name.')
-        },
-        widget=forms.TextInput(
-            attrs={
-                'size': 20,
-                'placeholder': _('First Name'),
-                'class': 'required',
-                'required': 'required',
-                'aria-required': 'true'
-            }
-        )
-    )
-    last_name = forms.CharField(
-        max_length=80,
-        required=True,
-        error_messages={
-            'required': _('Please enter your last name.')
-        },
-        widget=forms.TextInput(
-            attrs={
-                'size': 20,
-                'placeholder': _('Last Name'),
-                'class': 'required',
-                'required': 'required',
-                'aria-required': 'true'
-            }
-        )
-    )
-
-    title = forms.CharField(
-        max_length=40,
-        required=False,
-        widget=forms.TextInput(
-            attrs={
-                'size': 20,
-                'placeholder': _('Title')
-            }
-        )
-    )
-    company = forms.CharField(
-        max_length=40,
-        required=False,
-        widget=forms.TextInput(
-            attrs={
-                'size': 20,
-                'placeholder': _('Company'),
-            }
-        )
-    )
-    email = forms.EmailField(
-        max_length=80,
-        required=True,
-        error_messages={
-            'required': _('Please enter your email address.'),
-            'invalid': _('Please enter a valid email address')
-        },
-        widget=forms.TextInput(
-            attrs={
-                'size': 20,
-                'placeholder': _('Email'),
-                'class': 'required',
-                'required': 'required',
-                'aria-required': 'true'
-            }
-        )
-    )
-    phone = forms.CharField(
-        max_length=40,
-        required=False,
-        widget=forms.TextInput(
-            attrs={
-                'size': 20,
-                'placeholder': _('Phone')
-            }
-        )
-    )
-    mobile = forms.CharField(
-        max_length=40,
-        required=False,
-        widget=forms.TextInput(
-            attrs={
-                'size': 20,
-                'placeholder': _('Mobile')
-            }
-        )
-    )
-    city = forms.CharField(
-        required=False,
-        max_length=40,
-        widget=forms.TextInput(
-            attrs={
-                'placeholder': _('City')
-            }
-        )
-    )
-    state = forms.CharField(
-        required=False,
-        max_length=40,
-        widget=forms.TextInput(
-            attrs={
-                'placeholder': _('State/Province')
-            }
-        )
-    )
-    country = forms.CharField(
-        required=False,
-        max_length=40,
-        widget=forms.TextInput(
-            attrs={
-                'placeholder': _('Country')
-            }
-        )
-    )
-
-    industry = forms.ChoiceField(
-        required=False,
-        choices=Profile.INDUSTRY_CHOICES
-    )
-
-    type_of_device = forms.MultipleChoiceField(
-        required=False,
-        choices=Profile.DEVICE_CHOICES
-    )
-
-    mobile_product_interest = forms.MultipleChoiceField(
-        required=False,
-        choices=Profile.INTEREST_CHOICES
-    )
-
-    description = forms.CharField(
-        required=False,
-        widget=forms.Textarea(
-            attrs={
-                'placeholder': _('Description'),
-                'rows': '',
-                'cols': ''
-            }
-        )
-    )
-
-    lead_source = forms.CharField(
-        initial="mobilepartners.mozilla.org",
-        max_length=26,
-        widget=forms.HiddenInput()
-    )
-
-    superpriority = forms.BooleanField(widget=HoneyPotWidget, required=False)
-    if settings.DEBUG_SALESFORCE:
-        debug = forms.IntegerField(
-            required=False,
-            help_text=_("set DEBUG_SALESFORCE=False to remove this field")
-        )
-        debugEmail = forms.EmailField(
-            required=False,
-            help_text=_("set DEBUG_SALESFORCE=False to remove this field")
-        )
+    superpriority = forms.BooleanField(required=False, widget=HoneyPotWidget)
 
     class Meta:
         model = User
         fields = ("first_name", "last_name", "email")
+        required_fields = ('first_name', 'last_name', 'email', 'legal_entity',
+                           'company', 'street', 'city', 'country')
 
     def __init__(self, *args, **kwargs):
         super(UserRegistrationLeadForm, self).__init__(*args, **kwargs)
-
-        self._signup = self.instance.id is None
-        user_fields = User._meta.get_all_field_names()
-        try:
-            self.fields["username"].help_text = _(
-                        "Only letters, numbers, dashes or underscores please")
-        except KeyError:
-            pass
         for field in self.fields:
-            # Make user fields required.
-            if field in user_fields:
+            if field in self.Meta.required_fields:
                 self.fields[field].required = True
-            # Disable auto-complete for password fields.
-            # Password isn't required for profile update.
-            if field.startswith("password"):
-                self.fields[field].widget.attrs["autocomplete"] = "off"
-                self.fields[field].widget.attrs.pop("required", "")
-                if not self._signup:
-                    self.fields[field].required = False
-                    if field == "password1":
-                        self.fields[field].help_text = _(
-                        "Leave blank unless you want to change your password")
-
-    def clean_password2(self):
-        """
-        Ensure the password fields are equal, and match the minimum
-        length defined by ``ACCOUNTS_MIN_PASSWORD_LENGTH``.
-        """
-        password1 = self.cleaned_data.get("password1")
-        password2 = self.cleaned_data.get("password2")
-
-        if password1:
-            errors = []
-            if password1 != password2:
-                errors.append(_("Passwords do not match"))
-            if len(password1) < settings.ACCOUNTS_MIN_PASSWORD_LENGTH:
-                errors.append(_("Password must be at least %s characters") %
-                              settings.ACCOUNTS_MIN_PASSWORD_LENGTH)
-            if errors:
-                self._errors["password1"] = self.error_class(errors)
-        return password2
-
-    def clean_email(self):
-        """
-        Ensure the email address is not already registered.
-        """
-        email = self.cleaned_data.get("email")
-        qs = User.objects.exclude(id=self.instance.id).filter(email=email)
-        if not qs.exists():
-            return email
-        raise forms.ValidationError(_("This email is already registered"))
-
-    def save(self, *args, **kwargs):
-        """
-        Create the new user. If no username is supplied (may be hidden
-        via ``ACCOUNTS_PROFILE_FORM_EXCLUDE_FIELDS`` or
-        ``ACCOUNTS_NO_USERNAME``), we generate a unique username.
-        """
-
-        kwargs["commit"] = False
-        user = super(UserRegistrationLeadForm, self).save(*args, **kwargs)
-        try:
-            self.cleaned_data["username"]
-        except KeyError:
-            if not self.instance.username:
-                username = "%(first_name)s %(last_name)s" % self.cleaned_data
-                if not username.strip():
-                    username = self.cleaned_data["email"].split("@")[0]
-                qs = User.objects.exclude(id=self.instance.id)
-                user.username = unique_slug(qs, "username", slugify(username))
-        password = self.cleaned_data.get("password1")
-        if password:
-            user.set_password(password)
-        elif self._signup:
-            try:
-                user.set_unusable_password()
-            except AttributeError:
-                # This could happen if using a custom user model that
-                # doesn't inherit from Django's AbstractBaseUser.
-                pass
-        user.save()
-
-        if self._signup:
-            settings.use_editable()
-            if (settings.ACCOUNTS_VERIFICATION_REQUIRED or
-                    settings.ACCOUNTS_APPROVAL_REQUIRED):
-                user.is_active = False
-                user.save()
-            else:
-                token = default_token_generator.make_token(user)
-                user = authenticate(uidb36=int_to_base36(user.id),
-                                    token=token,
-                                    is_active=True)
-
-        create_or_update_profile(user, self.cleaned_data)
-        return user
+                self.fields[field].widget.attrs.update(
+                    {'class': 'required',
+                     'required': 'required',
+                     'aria-required': 'true'})
+            self.fields[field].widget.attrs['placeholder'] = (
+                self.fields[field].label)

--- a/registration_salesforce/migrations/0002_auto__add_field_profile_legal_entity__add_field_profile_company_zip_co.py
+++ b/registration_salesforce/migrations/0002_auto__add_field_profile_legal_entity__add_field_profile_company_zip_co.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Profile.legal_entity'
+        db.add_column(u'registration_salesforce_profile', 'legal_entity',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=80, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Profile.company_zip_code'
+        db.add_column(u'registration_salesforce_profile', 'company_zip_code',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=40, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Profile.website'
+        db.add_column(u'registration_salesforce_profile', 'website',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=80, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Profile.street'
+        db.add_column(u'registration_salesforce_profile', 'street',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=80, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Profile.zip_code'
+        db.add_column(u'registration_salesforce_profile', 'zip_code',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=10, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Profile.language_preference'
+        db.add_column(u'registration_salesforce_profile', 'language_preference',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=40, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Profile.legal_entity'
+        db.delete_column(u'registration_salesforce_profile', 'legal_entity')
+
+        # Deleting field 'Profile.company_zip_code'
+        db.delete_column(u'registration_salesforce_profile', 'company_zip_code')
+
+        # Deleting field 'Profile.website'
+        db.delete_column(u'registration_salesforce_profile', 'website')
+
+        # Deleting field 'Profile.street'
+        db.delete_column(u'registration_salesforce_profile', 'street')
+
+        # Deleting field 'Profile.zip_code'
+        db.delete_column(u'registration_salesforce_profile', 'zip_code')
+
+        # Deleting field 'Profile.language_preference'
+        db.delete_column(u'registration_salesforce_profile', 'language_preference')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'registration_salesforce.profile': {
+            'Meta': {'object_name': 'Profile'},
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '40', 'blank': 'True'}),
+            'company': ('django.db.models.fields.CharField', [], {'max_length': '40', 'blank': 'True'}),
+            'company_zip_code': ('django.db.models.fields.CharField', [], {'max_length': '40', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '40', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'industry': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'language_preference': ('django.db.models.fields.CharField', [], {'max_length': '40', 'blank': 'True'}),
+            'last_salesforce_sync': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'legal_entity': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'mobile': ('django.db.models.fields.CharField', [], {'max_length': '40', 'blank': 'True'}),
+            'mobile_product_interest': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True', 'blank': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '40', 'blank': 'True'}),
+            'salesforce_id': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'salesforce_sync': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '40', 'blank': 'True'}),
+            'street': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '40', 'blank': 'True'}),
+            'type_of_device': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['auth.User']", 'unique': 'True'}),
+            'website': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '10', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['registration_salesforce']

--- a/registration_salesforce/models.py
+++ b/registration_salesforce/models.py
@@ -1,73 +1,85 @@
 from django.contrib.auth.models import User
 from django.db import models
+from django.utils.translation import ugettext_lazy as _
 from django_extensions.db.fields import (
     CreationDateTimeField, ModificationDateTimeField)
 
 
 class Profile(models.Model):
     INDUSTRY_CHOICES = (
-        ('', '--None--'),
-        ('Agriculture', 'Agriculture'),
-        ('Apparel', 'Apparel'),
-        ('Banking', 'Banking'),
-        ('Biotechnology', 'Biotechnology'),
-        ('Chemicals', 'Chemicals'),
-        ('Communications', 'Communications'),
-        ('Construction', 'Construction'),
-        ('Consulting', 'Consulting'),
-        ('Education', 'Education'),
-        ('Electronics', 'Electronics'),
-        ('Energy', 'Energy'),
-        ('Engineering', 'Engineering'),
-        ('Entertainment', 'Entertainment'),
-        ('Environmental', 'Environmental'),
-        ('Finance', 'Finance'),
-        ('Food &amp; Beverage', 'Food &amp; Beverage'),
-        ('Government', 'Government'),
-        ('Healthcare', 'Healthcare'),
-        ('Hospitality', 'Hospitality'),
-        ('Insurance', 'Insurance'),
-        ('Machinery', 'Machinery'),
-        ('Manufacturing', 'Manufacturing'),
-        ('Media', 'Media'),
-        ('Not For Profit', 'Not For Profit'),
-        ('Other', 'Other'),
-        ('Recreation', 'Recreation'),
-        ('Retail', 'Retail'),
-        ('Shipping', 'Shipping'),
-        ('Technology', 'Technology'),
-        ('Telecommunications', 'Telecommunications'),
-        ('Transportation', 'Transportation'),
-        ('Utilities', 'Utilities'),
+        ('', _('--None--')),
+        ('Agriculture', _('Agriculture')),
+        ('Apparel', _('Apparel')),
+        ('Banking', _('Banking')),
+        ('Biotechnology', _('Biotechnology')),
+        ('Chemicals', _('Chemicals')),
+        ('Communications', _('Communications')),
+        ('Construction', _('Construction')),
+        ('Consulting', _('Consulting')),
+        ('Education', _('Education')),
+        ('Electronics', _('Electronics')),
+        ('Energy', _('Energy')),
+        ('Engineering', _('Engineering')),
+        ('Entertainment', _('Entertainment')),
+        ('Environmental', _('Environmental')),
+        ('Finance', _('Finance')),
+        ('Food &amp; Beverage', _('Food &amp; Beverage')),
+        ('Government', _('Government')),
+        ('Healthcare', _('Healthcare')),
+        ('Hospitality', _('Hospitality')),
+        ('Insurance', _('Insurance')),
+        ('Machinery', _('Machinery')),
+        ('Manufacturing', _('Manufacturing')),
+        ('Media', _('Media')),
+        ('Not For Profit', _('Not For Profit')),
+        ('Other', _('Other')),
+        ('Recreation', _('Recreation')),
+        ('Retail', _('Retail')),
+        ('Shipping', _('Shipping')),
+        ('Technology', _('Technology')),
+        ('Telecommunications', _('Telecommunications')),
+        ('Transportation', _('Transportation')),
+        ('Utilities', _('Utilities')),
     )
 
     DEVICE_CHOICES = (
-        ('Tablet', 'Tablet'),
-        ('Wearable', 'Wearable'),
-        ('Other', 'Other'),
+        ('Tablet', _('Tablet')),
+        ('Wearable', _('Wearable')),
+        ('Other', _('Other')),
     )
 
     INTEREST_CHOICES = (
-        ('Firefox OS', 'Firefox OS'),
-        ('Firefox Marketplace', 'Firefox Marketplace'),
-        ('Other', 'Other'),
+        ('Firefox OS', _('Firefox OS')),
+        ('Firefox Marketplace', _('Firefox Marketplace')),
+        ('Other', _('Other')),
     )
 
     user = models.OneToOneField(User)
-    title = models.CharField(max_length=40, blank=True)
-    company = models.CharField(max_length=40, blank=True)
-    phone = models.CharField(max_length=40, blank=True)
-    mobile = models.CharField(max_length=40, blank=True)
-    city = models.CharField(blank=True, max_length=40)
-    state = models.CharField(blank=True, max_length=40)
-    country = models.CharField(blank=True, max_length=40)
+    title = models.CharField(_('title'), blank=True, max_length=40)
+    legal_entity = models.CharField(
+        _('legal entity name'), blank=True, max_length=80)
+    company = models.CharField(_('company name'), max_length=40)
+    company_zip_code = models.CharField(
+        _('company zip / postal code'), blank=True, max_length=40)
+    website = models.CharField(
+        _('company website '), blank=True, max_length=80)
+    street = models.CharField(_('street'), blank=True, max_length=80)
+    city = models.CharField(_('city'), blank=True, max_length=40)
+    state = models.CharField(_('state'), blank=True, max_length=40)
+    zip_code = models.CharField(
+        _('zip / postal code'), blank=True, max_length=10)
+    country = models.CharField(_('country'), blank=True, max_length=40)
+    phone = models.CharField(_('phone'), blank=True, max_length=40)
+    mobile = models.CharField(_('mobile'), blank=True, max_length=40)
     industry = models.CharField(
         blank=True, choices=INDUSTRY_CHOICES, max_length=80)
     type_of_device = models.CharField(
         blank=True, choices=DEVICE_CHOICES, max_length=80)
     mobile_product_interest = models.CharField(
         blank=True, choices=INTEREST_CHOICES, max_length=80)
-    description = models.TextField(blank=True)
+    language_preference = models.CharField(
+        _('language preference'), blank=True, max_length=40)
+    description = models.TextField(_('description'), blank=True)
     salesforce_id = models.CharField(blank=True, max_length=80)
     salesforce_sync = models.BooleanField(default=True)
     last_salesforce_sync = models.DateTimeField(

--- a/registration_salesforce/views.py
+++ b/registration_salesforce/views.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-import requests
-
 from django.contrib.auth import login as auth_login
 from django.contrib.messages import info
 from django.core.exceptions import PermissionDenied
@@ -49,4 +47,3 @@ def signup(request, template="accounts/account_signup.html"):
             return login_redirect(request)
     context = {"form": form, "title": _("Sign up")}
     return render(request, template, context)
-


### PR DESCRIPTION
Use UserRegistrationLeadForm in update_profile by adding
ACCOUNTS_PROFILE_FORM_CLASS and AUTH_PROFILE_MODULE settings
UserRegistrationLeadForm now inherits from mezzanine.accounts.forms

Add ACCOUNTS_PROFILE_FORM_EXCLUDE_FIELDS to settings
Exclude salesforce_id, salesforce_sync, and last_salesforce_sync

Add fields to LEAD_PROFILE and remove LEAD_FIELDS
Use Mobile__c instead of MobilePhone field
Created custom field because MobilePhone not accessible via API

Fix flake8 errors
