### PR TITLE
Remove Duplicate Site Permissions

### DIFF
--- a/sandstone/admin.py
+++ b/sandstone/admin.py
@@ -83,7 +83,7 @@ class SandstoneLinkAdmin(TranslatableMixin, LinkAdmin):
     tranlsated_fields = ['title', ]
 
 
-def _remove_duplicate_permissions(user):
+def remove_duplicate_permissions(user):
     """Delete duplicate SitePermission records, if any, for the user."""
     if user.pk:
         permissions = SitePermission.objects.filter(user=user)
@@ -96,7 +96,7 @@ class SandstoneUserAdmin(UserProfileAdmin):
 
     def save_related(self, request, form, formsets, change):
         super(SandstoneUserAdmin, self).save_related(request, form, formsets, change)
-        _remove_duplicate_permissions(form.instance)
+        remove_duplicate_permissions(form.instance)
 
 
 admin.site.unregister(Form)


### PR DESCRIPTION
Fixes #186. Customizes the user admin to remove duplicate/multiple `SitePermission` records which could previously be created by double submitting the save form. To fix existing users they simply need to be saved again. I've created a Mezzanine issue to enforce this at the DB level and I'll be submitting a PR to fix it there in an upcoming release.

**Note:** `registration_salesforce/admin.py` was removed in 067554391826b903fbf746930908e65a27cbcf52 you need to ensure the .pyc file has been removed to see this change.
