### PR TITLE
move .env setup into dockerfile to make fig up work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM python:2.7
 ADD . /code
 WORKDIR /code
+
+# Build .env for fig
+# TODO: use a different local.py to reference the db host as db_1
+RUN echo "" > .env && echo 'DATABASE_URL=postgres://postgres:foobar@${DB_1_PORT_5432_TCP_ADDR}:${DB_1_PORT_5432_TCP_PORT}/postgres' >> .env && echo "DEBUG=True" >> .env
+
 RUN apt-get update
 
 # Generate locales
@@ -15,3 +20,4 @@ RUN npm install -g less
 RUN pip install -r build-requirements.txt
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 RUN peep install -r requirements/dev.txt
+

--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,7 @@ clean-fig:
 clean-env:
 	@rm -rf env
 
-.PHONY: .env
-.env:
-	@echo "" > .env
-	@echo "DATABASE_URL=postgres://postgres:foobar@${DB_1_PORT_5432_TCP_ADDR}:${DB_1_PORT_5432_TCP_PORT}/postgres" >> .env
-	@echo "DEBUG=True" >> .env
-
-start: .env
+start: 
 	@python manage.py syncdb --migrate --noinput
 	@python manage.py runserver 0.0.0.0:8000
 


### PR DESCRIPTION
Should allow `fig up` for those who have fig globally installed, and `make up` for those who don't.

r?
