### PR TITLE
use fig up, instead of seperate container starts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,8 @@ build: .build
 
 .PHONY: up
 up: build
-# need to sleep a bit to ensure container is fully up
-# so that environment variables are properly populated
-	@. env/bin/activate; fig up -d db; sleep 1
-	@. env/bin/activate; fig up -d app
+# Run Fig up to start the fig stack in the background.
+	@. env/bin/activate; fig up -d
 
 .PHONY: down
 down:


### PR DESCRIPTION
on slower systems `sleep 1` might not be sufficant.  `fig up` will launch containers in the right order, and should wait till each is fully launched before spinning up the next.  Changed `Makefile` to reflect this.
